### PR TITLE
Fixes polyfill dependency within node/Gatsby

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
-require('smoothscroll-polyfill').polyfill();
+if ('undefined' !== typeof window) {
+	require('smoothscroll-polyfill').polyfill();
+}
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,9 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-require('smoothscroll-polyfill').polyfill();
+if ('undefined' !== typeof window) {
+	require('smoothscroll-polyfill').polyfill();
+}
 
 
 var Element = function Element(props) {


### PR DESCRIPTION
I wasn't able to use this package within Gatsby because `window` is referenced within the polyfill but is not available to node.